### PR TITLE
bumped sgr-commhandler to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,39 +71,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.vavr</groupId>
-			<artifactId>vavr</artifactId>
-			<version>0.10.4</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.smartgridready</groupId>
-			<artifactId>sgr-specification</artifactId>
-			<version>2.0_2024-10-08</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.smartgridready</groupId>
 			<artifactId>sgr-commhandler</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>2.0.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.smartgridready</groupId>
 			<artifactId>easymodbus</artifactId>
 			<version>2.0.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.smartgridready</groupId>
-			<artifactId>sgr-driver-api</artifactId>
-			<version>2.0.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>io.github.java-native</groupId>
-			<artifactId>jssc</artifactId>
-			<version>2.9.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
set commhandler version to 2.0.1.
removed transitive dependencies that are already covered by commhandler.