### PR TITLE
Implement Github workflow for building intermediary for ARM64 architecture (only production version - `master` branch

### DIFF
--- a/.github/workflows/on-push-arm64.yaml
+++ b/.github/workflows/on-push-arm64.yaml
@@ -4,13 +4,13 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['**']
+    branches: ['master']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain,
 # and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: smartgridready/sgr-intermediary
+  IMAGE_NAME: smartgridready/sgr-intermediary-arm64
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build Docker image
         id: build
-        run: docker buildx build --platform linux/arm64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master-arm64 .
+        run: docker buildx build --platform linux/arm64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} .
 
       - name: Push Docker image
         id: push

--- a/.github/workflows/on-push-arm64.yaml
+++ b/.github/workflows/on-push-arm64.yaml
@@ -1,0 +1,73 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['29-arm64-image']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain,
+# and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: SmartGridready/sgr-intermediary
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Restore Maven cache
+        uses: skjolber/maven-cache-github-action@v3.1.1
+        with:
+          step: restore
+
+      - name: Run the Maven install phase
+        run: mvn --batch-mode --update-snapshots install
+
+      - name: Save Maven cache
+        uses: skjolber/maven-cache-github-action@v3.1.1
+        with:
+          step: save
+
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+
+      - name: Build Docker image
+        id: build
+        run: docker buildx build --platform linux/arm64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arm64:latest .
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/on-push-arm64.yaml
+++ b/.github/workflows/on-push-arm64.yaml
@@ -4,17 +4,17 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['29-arm64-image']
+    branches: ['**']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain,
 # and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: SmartGridready/sgr-intermediary
+  IMAGE_NAME: smartgridready/sgr-intermediary
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  build-and-push-image:
+  build-and-push-image-arm64:
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
@@ -66,8 +66,3 @@ jobs:
       - name: Build Docker image
         id: build
         run: docker buildx build --platform linux/arm64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arm64:latest .
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/on-push-arm64.yaml
+++ b/.github/workflows/on-push-arm64.yaml
@@ -53,16 +53,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
 
       - name: Build Docker image
         id: build
-        run: docker buildx build --platform linux/arm64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arm64:latest .
+        run: docker buildx build --platform linux/arm64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master-arm64 .
+
+      - name: Push Docker image
+        id: push
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master-arm64


### PR DESCRIPTION
Overall this workflow is a complete copy of the existing one, except for the docker image build part.

New steps:

```yaml
- name: Build Docker image
        id: build
        run: docker buildx build --platform linux/arm64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master-arm64 .

      - name: Push Docker image
        id: push
        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master-arm64
```

Resolves #29 