### PR TITLE
bumped commhandler to support current XSD specification.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>com.smartgridready</groupId>
 			<artifactId>sgr-commhandler</artifactId>
-			<version>2.3.0</version>
+			<version>2.3.1</version>
 		</dependency>
 
 		<dependency>
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>com.smartgridready</groupId>
 			<artifactId>sgr-driver-hivemq</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
updated commhandler to version 2.3.1 and HiveMQ driver to 2.0.1 (bugfix).

commhandler 2.3.1 is based on current XSD specification.